### PR TITLE
Change TestInstance to SiteTestInstance + delete useless methods

### DIFF
--- a/lib/testing_site_onlyoffice/registration/portal_mail.rb
+++ b/lib/testing_site_onlyoffice/registration/portal_mail.rb
@@ -14,7 +14,7 @@ module TestingSiteOnlyffice
     # user = AuthData.new(any params) or hash(see in "submit_invited_user" method), link = https://portal-name.onlyoffice.com/info?any keys
     # method will open browser, add passwords on invite page, click confirm and close browser
     def submit_user_by_link_web(user, link)
-      test_session = TestInstance.new(AuthData.new(link))
+      test_session = SiteTestInstance.new(AuthData.new(link))
       general_invite_page = SettingsGeneralAddNewUser.new(test_session)
       general_invite_page.submit_invited_user(user)
       test_session.webdriver.quit

--- a/lib/testing_site_onlyoffice/registration/portal_people.rb
+++ b/lib/testing_site_onlyoffice/registration/portal_people.rb
@@ -18,7 +18,7 @@ module TestingSiteOnlyffice
                   end
       log_new_portal("Add users: Count: #{user_list.count}")
       if user_list.length > 1
-        test = TestInstance.new(user_list.first)
+        test = SiteTestInstance.new(user_list.first)
         api = GeneralApiService.new(user_list.first.portal, user_list.first.email, user_list.first.password)
         user_link = api.portal.invite_user_url
         guest_link = api.portal.invite_visitor_url
@@ -139,27 +139,6 @@ module TestingSiteOnlyffice
     def get_mail_to_user_ired_mail(clone, current_time)
       clone.username += current_time.to_s if current_time != 1
       "#{clone.username}@#{SettingsData::DOMAIN}"
-    end
-
-    def add_users_to_portal(portal_data, user_list)
-      user_list.each do |current_user|
-        next unless current_user.type != :admin
-
-        p "current_user: #{current_user.first_name}"
-        admin = AuthData.new(portal_data.portal_name, portal_data.portal_login, portal_data.portal_pwd)
-        test = TestInstance.new(admin)
-        begin
-          login_page = LoginPage.new(test)
-          main_page = login_page.login_with
-          people_page = main_page.go_to_people
-          invitation_link_form = people_page.open_invitation_link_form
-          add_user_page = invitation_link_form.open_people_invitation_link_for(current_user.type)
-          add_user_page.add_current_user_by_link_and_relogin(current_user)
-        rescue StandardError
-          p "cant add user: #{current_user.first_name}"
-        end
-        test.webdriver.quit
-      end
     end
   end
 end

--- a/lib/testing_site_onlyoffice/registration/teamlab_portal_reg_web_helper.rb
+++ b/lib/testing_site_onlyoffice/registration/teamlab_portal_reg_web_helper.rb
@@ -106,14 +106,6 @@ module TestingSiteOnlyffice
                                           '//*[@id="ReleaseNewVersion"]//*[contains(@class, "btn-close")]').click
     end
 
-    def open_api_page
-      page_address = StaticDataTeamLab.portal_type == '.info' ? 'api.teamlab.info' : 'api.onlyoffice.com'
-      @test = TestInstance.new
-      @test.webdriver.open(page_address)
-      api_page = SiteApi.new(@test)
-      [api_page, @test]
-    end
-
     def open_page_teamlab_office(portal = get_full_portal_name('www'))
       log_new_portal('Init browser: Start')
       admin = AuthData.new(portal)

--- a/lib/testing_site_onlyoffice/site_helper.rb
+++ b/lib/testing_site_onlyoffice/site_helper.rb
@@ -46,22 +46,9 @@ module TestingSiteOnlyffice
       languages_list
     end
 
-    def check_wrong_portal_region(region)
-      regions = %w[com eu sg]
-      regions.delete(region.to_s)
-      wrong_region = regions.sample
-      portal = { com: SiteData::PORTAL_ADDRESS_COM, eu: SiteData::PORTAL_ADDRESS_EU, sg: SiteData::PORTAL_ADDRESS_SG,
-                 info: SiteData::PORTAL_ADDRESS_INFO }[region.to_sym]
-      wrong_portal = portal.gsub(".#{region}", ".#{wrong_region}")
-      admin = AuthData.new(wrong_portal)
-      @test = TestInstance.new(admin)
-      LoginPage.new(@test)
-      @test.webdriver.get_url.include? portal
-    end
-
     def wrong_portal_name
       wrong_portal = SiteData::PORTAL_ADDRESS.dup.insert(10, Time.now.nsec.to_s)
-      @test = TestInstance.new
+      @test = SiteTestInstance.new
       @test.webdriver.open('https://teamlab.info/?Site_Testing=4testing')
       @test.webdriver.open(wrong_portal)
       @test.webdriver.wait_until { @test.webdriver.driver.current_url.include? '/wrongportalname.aspx?url=' }


### PR DESCRIPTION
1. Change TestInstance to SiteTestInstance 
2. Delete methods that aren't used in TeamLab and Site projects