### PR TITLE
Change mobile app store title (nbsp was added)

### DIFF
--- a/lib/testing_site_onlyoffice/data/site_download_data.rb
+++ b/lib/testing_site_onlyoffice/data/site_download_data.rb
@@ -23,7 +23,7 @@ module TestingSiteOnlyoffice
 
     # Mobile
     MOBILE_GOOGLE = 'ONLYOFFICE Documents - Apps on Google Play'
-    MOBILE_APP_STORE = '‎ONLYOFFICE Documents on the App Store'
+    MOBILE_APP_STORE = 'ONLYOFFICE Documents on the App Store'
     MOBILE_IOS_CHANGELOG = 'Documents app for iOS changelog - ONLYOFFICE'
 
     # Connectors

--- a/lib/testing_site_onlyoffice/data/site_download_data.rb
+++ b/lib/testing_site_onlyoffice/data/site_download_data.rb
@@ -23,7 +23,7 @@ module TestingSiteOnlyoffice
 
     # Mobile
     MOBILE_GOOGLE = 'ONLYOFFICE Documents - Apps on Google Play'
-    MOBILE_APP_STORE = '‎ONLYOFFICE Documents on the App Store'
+    MOBILE_APP_STORE = '‎ONLYOFFICE Documents on the App Store'
     MOBILE_IOS_CHANGELOG = 'Documents app for iOS changelog - ONLYOFFICE'
 
     # Connectors

--- a/lib/testing_site_onlyoffice/solutions/site_home_use.rb
+++ b/lib/testing_site_onlyoffice/solutions/site_home_use.rb
@@ -79,7 +79,8 @@ module TestingSiteOnlyoffice
 
     def get_marketplace_title
       @instance.webdriver.wait_until { !download_now_desktop_editors_element.present? }
-      @instance.webdriver.get_title_of_current_tab
+      title = @instance.webdriver.get_title_of_current_tab
+      title.gsub(/\P{ASCII}/, ' ').strip
     end
   end
 end


### PR DESCRIPTION
Remove all non ASCII characters from mobile app store title, as ```nbsp``` was added