### PR TITLE
Check if download side page is opened for Open Source Docs

### DIFF
--- a/lib/testing_site_onlyoffice/get_onlyoffice/open_source_packages/site_open_source_docs.rb
+++ b/lib/testing_site_onlyoffice/get_onlyoffice/open_source_packages/site_open_source_docs.rb
@@ -34,6 +34,7 @@ module TestingSiteOnlyoffice
       if installer == :windows
         file_downloaded?(downloaded_installer)
       else
+        @instance.webdriver.wait_until { !check_opened_page_title.empty? } # Digitalocean title loading timeout
         check_opened_page_title == downloaded_installer
       end
     end


### PR DESCRIPTION
Add waiting for page title not empty as loading DigitalOcean page takes time.