### PR TITLE
Download refactoring - delete repeated methods from constructor (commercial and document_builder)

### DIFF
--- a/lib/testing_site_onlyoffice/data/site_document_builder_info.json
+++ b/lib/testing_site_onlyoffice/data/site_document_builder_info.json
@@ -1,0 +1,13 @@
+{
+  "windows": {
+    "download": "docbuilder_x64.exe"
+  },
+  "debian": {
+    "download": "onlyoffice-documentbuilder_amd64.deb"
+  },
+  "centos": {
+    "download": "onlyoffice-documentbuilder.x86_64.rpm"
+  },
+  "instruction": "ONLYOFFICE Api Documentation - Getting started",
+  "whats_new": "DocumentBuilder/CHANGELOG.md at master · ONLYOFFICE/DocumentBuilder · GitHub"
+}

--- a/lib/testing_site_onlyoffice/data/site_download_data.rb
+++ b/lib/testing_site_onlyoffice/data/site_download_data.rb
@@ -124,8 +124,8 @@ module TestingSiteOnlyoffice
       %i[windows debian centos]
     end
 
-    DOCUMENT_BUILDER_INSTRUCTION = 'ONLYOFFICE Api Documentation - Getting started'
-    DOCUMENT_BUILDER_CHANGELOG = 'DocumentBuilder/CHANGELOG.md at master · ONLYOFFICE/DocumentBuilder · GitHub'
-    FORK_ME_ON_GITHUB = 'GitHub - ONLYOFFICE/DocumentBuilder: ONLYOFFICE Document Builder is powerful text, spreadsheet, presentation and PDF generating tool'
+    def self.document_builder_info
+      @document_builder_info ||= JSON.parse(File.read("#{__dir__}/site_document_builder_info.json"))
+    end
   end
 end

--- a/lib/testing_site_onlyoffice/get_onlyoffice/commercial_packages/site_commercial_block_constructor.rb
+++ b/lib/testing_site_onlyoffice/get_onlyoffice/commercial_packages/site_commercial_block_constructor.rb
@@ -4,7 +4,7 @@ require_relative 'site_commercial_download_form'
 
 module TestingSiteOnlyoffice
   class SiteCommercialBlockConstructor
-    attr_accessor :instance, :instruction_xpath, :download_xpath
+    attr_accessor :instance, :instruction_xpath, :download_xpath, :version_xpath, :release_date_xpath
 
     include PageObject
 
@@ -21,7 +21,7 @@ module TestingSiteOnlyoffice
         @instruction_xpath = "#{@download_xpath}/../../div/p/a[not(contains(@href, 'changelog'))]"
       end
       @version_xpath = "#{@download_xpath}/../../div/p[1]"
-      @release_data_xpath = "#{@download_xpath}/../../div/p[2]"
+      @release_date_xpath = "#{@download_xpath}/../../div/p[2]"
       wait_to_load
     end
 
@@ -29,10 +29,6 @@ module TestingSiteOnlyoffice
       @instance.webdriver.wait_until do
         @instance.webdriver.get_element(@download_xpath).present?
       end
-    end
-
-    def click_read_instruction
-      @instance.webdriver.get_element(@instruction_xpath).click
     end
 
     def click_install_button
@@ -52,20 +48,6 @@ module TestingSiteOnlyoffice
       when 'docs_developer'
         SitePriceDocsDeveloper.new(@instance)
       end
-    end
-
-    def get_installer_version
-      version_text = @instance.webdriver.get_text(@version_xpath)
-      get_release_date_or_version(version_text)
-    end
-
-    def get_installer_release_date
-      release_date_text = @instance.webdriver.get_text(@release_data_xpath)
-      get_release_date_or_version(release_date_text)
-    end
-
-    def get_release_date_or_version(text)
-      text.match(%r{\d+[./]\d+[./]\d+}).to_s
     end
   end
 end

--- a/lib/testing_site_onlyoffice/get_onlyoffice/commercial_packages/site_commercial_docs.rb
+++ b/lib/testing_site_onlyoffice/get_onlyoffice/commercial_packages/site_commercial_docs.rb
@@ -3,12 +3,14 @@
 require_relative '../../modules/site_toolbar'
 require_relative 'modules/site_commercial_toolbar'
 require_relative '../modules/site_download_helper'
+require_relative '../modules/site_block_constructor_helper'
 require_relative 'site_commercial_block_constructor'
 require_relative 'modules/site_commercial_download_helper'
 
 module TestingSiteOnlyoffice
   class SiteCommercialDocs
     include PageObject
+    include SiteBlockConstructorHelper
     include SiteDownloadHelper
     include SiteCommercialDownloadHelper
     include SiteToolbar

--- a/lib/testing_site_onlyoffice/get_onlyoffice/commercial_packages/site_commercial_workspace.rb
+++ b/lib/testing_site_onlyoffice/get_onlyoffice/commercial_packages/site_commercial_workspace.rb
@@ -3,12 +3,14 @@
 require_relative '../../modules/site_toolbar'
 require_relative 'modules/site_commercial_toolbar'
 require_relative '../modules/site_download_helper'
+require_relative '../modules/site_block_constructor_helper'
 require_relative 'site_commercial_block_constructor'
 require_relative 'modules/site_commercial_download_helper'
 
 module TestingSiteOnlyoffice
   class SiteCommercialWorkspace
     include PageObject
+    include SiteBlockConstructorHelper
     include SiteDownloadHelper
     include SiteCommercialDownloadHelper
     include SiteToolbar

--- a/lib/testing_site_onlyoffice/get_onlyoffice/modules/site_block_constructor_helper.rb
+++ b/lib/testing_site_onlyoffice/get_onlyoffice/modules/site_block_constructor_helper.rb
@@ -6,17 +6,12 @@ module TestingSiteOnlyoffice
       @instance.webdriver.get_element(xpath).click
     end
 
-    def get_installer_version(version_xpath)
-      version_text = @instance.webdriver.get_text(version_xpath)
-      get_release_date_or_version(version_text)
+    def get_installer_release_date_or_version(release_date_xpath)
+      date_text = @instance.webdriver.get_text(release_date_xpath)
+      fetch_release_date_or_version(date_text)
     end
 
-    def get_installer_release_date(release_date_xpath)
-      release_date_text = @instance.webdriver.get_text(release_date_xpath)
-      get_release_date_or_version(release_date_text)
-    end
-
-    def get_release_date_or_version(text)
+    def fetch_release_date_or_version(text)
       text.match(%r{\d+[./]\d+[./]\d+}).to_s
     end
   end

--- a/lib/testing_site_onlyoffice/get_onlyoffice/modules/site_block_constructor_helper.rb
+++ b/lib/testing_site_onlyoffice/get_onlyoffice/modules/site_block_constructor_helper.rb
@@ -6,8 +6,8 @@ module TestingSiteOnlyoffice
       @instance.webdriver.get_element(xpath).click
     end
 
-    def get_installer_release_date_or_version(release_date_xpath)
-      date_text = @instance.webdriver.get_text(release_date_xpath)
+    def get_installer_release_date_or_version(date_xpath)
+      date_text = @instance.webdriver.get_text(date_xpath)
       fetch_release_date_or_version(date_text)
     end
 

--- a/lib/testing_site_onlyoffice/get_onlyoffice/open_source_packages/document_builder/site_document_builder_constructor.rb
+++ b/lib/testing_site_onlyoffice/get_onlyoffice/open_source_packages/document_builder/site_document_builder_constructor.rb
@@ -3,7 +3,7 @@
 
 module TestingSiteOnlyoffice
   class SiteDocumentBuilderConstructor
-    attr_accessor :instance, :instruction_xpath, :download_xpath
+    attr_accessor :instance, :instruction_xpath, :download_xpath, :whats_new_xpath, :version_xpath, :release_date_xpath
 
     include PageObject
 
@@ -13,7 +13,7 @@ module TestingSiteOnlyoffice
       @installer = installer
       @download_xpath = "//a[contains(@id,'onlyoffice_document_builder_for_#{installer}')]"
       @instruction_xpath = "#{@download_xpath}/../..//a[contains(@href,'gettingstarted')]"
-      @whats_new_link = "#{@download_xpath}/../..//a[contains(@href,'CHANGELOG')]"
+      @whats_new_xpath = "#{@download_xpath}/../..//a[contains(@href,'CHANGELOG')]"
       @version_xpath = "#{@download_xpath}/../../div/p[1]"
       @release_date_xpath = "#{@download_xpath}/../../div/p[2]"
       wait_to_load
@@ -23,34 +23,6 @@ module TestingSiteOnlyoffice
       @instance.webdriver.wait_until do
         @instance.webdriver.get_element(@download_xpath).present?
       end
-    end
-
-    def click_read_instruction
-      @instance.webdriver.get_element(@instruction_xpath).click
-    end
-
-    def click_whats_new_link
-      @instance.webdriver.get_element(@whats_new_link).click
-    end
-
-    def get_installer_version
-      version_text = @instance.webdriver.get_text(@version_xpath)
-      get_release_date_or_version(version_text)
-    end
-
-    def get_installer_release_date
-      release_date_text = @instance.webdriver.get_text(@release_date_xpath)
-      get_release_date_or_version(release_date_text)
-    end
-
-    def get_release_date_or_version(text)
-      text.match(%r{\d+[./]\d+[./]\d+}).to_s
-    end
-
-    def get_extension
-      { windows: :windows,
-        debian: :deb,
-        centos: :rpm }
     end
   end
 end

--- a/lib/testing_site_onlyoffice/get_onlyoffice/open_source_packages/document_builder/site_open_source_document_builder.rb
+++ b/lib/testing_site_onlyoffice/get_onlyoffice/open_source_packages/document_builder/site_open_source_document_builder.rb
@@ -4,11 +4,13 @@
 require_relative '../../../modules/site_toolbar'
 require_relative '../modules/site_open_source_toolbar'
 require_relative '../../modules/site_download_helper'
+require_relative '../../modules/site_block_constructor_helper'
 require_relative 'site_document_builder_constructor'
 
 module TestingSiteOnlyoffice
   class SiteOpenSourceDocumentBuilder
     include PageObject
+    include SiteBlockConstructorHelper
     include SiteDownloadHelper
     include SiteToolbar
     include SiteToolbarOpenSource

--- a/shared_examples/commercial_installer_download.rb
+++ b/shared_examples/commercial_installer_download.rb
@@ -37,8 +37,8 @@ shared_examples_for 'commercial_installer_download' do |product, installers_list
         @current_installation = installers_download_page.get_blocks_by_product(product, installer)
       end
 
-      it "[Site][DownloadCommercial][#{product}]  instruction link for `#{installer}` alive /download.aspx" do
-        @current_installation.click_read_instruction
+      it "[Site][DownloadCommercial][#{product}] instruction link for `#{installer}` alive /download.aspx" do
+        installers_download_page.click_constructor_link(@current_installation.instruction_xpath)
         instruction_title = SiteDownloadData.commercial_info[product.downcase][installer.to_s]['instruction']
         expect(installers_download_page.check_opened_page_title).to eq(instruction_title)
       end
@@ -52,8 +52,8 @@ shared_examples_for 'commercial_installer_download' do |product, installers_list
       end
 
       it "[Site][DownloadCommercial][#{product}] version and realise date is not empty for `#{installer}`/download-commercial.aspx" do
-        expect(@current_installation.get_installer_release_date).not_to be_empty
-        expect(@current_installation.get_installer_version).not_to be_empty
+        expect(installers_download_page.get_installer_release_date_or_version(@current_installation.release_date_xpath)).not_to be_empty
+        expect(installers_download_page.get_installer_release_date_or_version(@current_installation.version_xpath)).not_to be_empty
       end
     end
   end

--- a/shared_examples/desktop_installer_download.rb
+++ b/shared_examples/desktop_installer_download.rb
@@ -46,8 +46,8 @@ shared_examples_for 'desktop_installer_download' do |installers_list|
       end
 
       it "[Site][DownloadDesktop] version and realise date is not empty for `#{installer}`/download-desktop.aspx#desktop" do
-        expect(installers_download_page.get_installer_release_date(@current_installation.release_date_xpath)).not_to be_empty
-        expect(installers_download_page.get_installer_version(@current_installation.release_date_xpath)).not_to be_empty
+        expect(installers_download_page.get_installer_release_date_or_version(@current_installation.release_date_xpath)).not_to be_empty
+        expect(installers_download_page.get_installer_release_date_or_version(@current_installation.version_xpath)).not_to be_empty
       end
     end
   end

--- a/shared_examples/document_builder_download.rb
+++ b/shared_examples/document_builder_download.rb
@@ -6,18 +6,19 @@ shared_examples_for 'document_builder_download' do |installers_list|
       end
 
       it "[Site][DownloadDocumentBuilder][#{installer}] 'Download' button for`#{installer}`/download.aspx#builder" do
-        expect(installers_download_page).to be_link_alive(@current_installation.download_xpath)
-        expect(installers_download_page).to be_download_link_valid(@current_installation.download_xpath, @current_installation.get_extension[installer])
+        expected_download_file = TestingSiteOnlyoffice::SiteDownloadData.document_builder_info[installer.to_s]['download']
+        expect(installers_download_page).to be_link_alive_and_valid(@current_installation.download_xpath, expected_download_file)
       end
 
       it "[Site][DownloadDocumentBuilder][#{installer}] 'Read installation instructions' works for`#{installer}`/download.aspx#builder" do
-        @current_installation.click_read_instruction
-        expect(installers_download_page.check_opened_page_title).to eq(TestingSiteOnlyoffice::SiteDownloadData::DOCUMENT_BUILDER_INSTRUCTION)
+        installers_download_page.click_constructor_link(@current_installation.instruction_xpath)
+        expected_instruction = TestingSiteOnlyoffice::SiteDownloadData.document_builder_info['instruction']
+        expect(installers_download_page.check_opened_page_title).to eq(expected_instruction)
       end
 
       it "[Site][DownloadDocumentBuilder][#{installer}] version and realise date is not empty for `#{installer}`/download.aspx#builder" do
-        expect(@current_installation.get_installer_release_date).not_to be_empty
-        expect(@current_installation.get_installer_version).not_to be_empty
+        expect(installers_download_page.get_installer_release_date_or_version(@current_installation.release_date_xpath)).not_to be_empty
+        expect(installers_download_page.get_installer_release_date_or_version(@current_installation.version_xpath)).not_to be_empty
       end
     end
   end

--- a/spec/functional/get_onlyoffice/site_open_source_document_builder_spec.rb
+++ b/spec/functional/get_onlyoffice/site_open_source_document_builder_spec.rb
@@ -16,8 +16,9 @@ describe 'Open source Document builder download' do
     TestingSiteOnlyoffice::SiteDownloadData.document_builder_list.each do |installer|
       it "[Site][DownloadDocumentBuilder][#{installer}] 'Whats new' button works for`#{installer}`/download.aspx#builder" do
         @current_installation = @document_builder_download_page.installer_document_builder_block(installer)
-        @current_installation.click_whats_new_link
-        expect(@document_builder_download_page.check_opened_page_title).to eq(TestingSiteOnlyoffice::SiteDownloadData::DOCUMENT_BUILDER_CHANGELOG)
+        @document_builder_download_page.click_constructor_link(@current_installation.whats_new_xpath)
+        expected_whats_new = TestingSiteOnlyoffice::SiteDownloadData.document_builder_info['whats_new']
+        expect(@document_builder_download_page.check_opened_page_title).to eq(expected_whats_new)
       end
     end
 


### PR DESCRIPTION
1. Delete repeated methods from constructor for commercial and document builder
2. Separate document builder data to json