### PR TITLE
Sort language list before comparing

### DIFF
--- a/spec/site_hourly_check_spec.rb
+++ b/spec/site_hourly_check_spec.rb
@@ -11,7 +11,7 @@ describe 'SiteHourlyCheck' do
     end
 
     it '[Site] Check exists languages' do
-      expect(@site_home_page.get_all_language_from_site).to eq(TestingSiteOnlyoffice::SiteData.site_languages)
+      expect(@site_home_page.get_all_language_from_site.sort).to eq(TestingSiteOnlyoffice::SiteData.site_languages.sort)
     end
 
     it '[Site] Check link Personal Office' do


### PR DESCRIPTION
Language list orders is different for .info and .com portal
for some reason
See [here](https://t.me/c/1440851975/4815)
Continue of #189