### PR TITLE
Delete sting modifying due to frozen_string_literal

### DIFF
--- a/lib/testing_site_onlyoffice/test_manger/test_manager.rb
+++ b/lib/testing_site_onlyoffice/test_manger/test_manager.rb
@@ -30,7 +30,7 @@ module TestingSiteOnlyoffice
     # @param [String] comment is a data for result
     def add_result(example, instance, comment = '')
       result = @tcm_helper.parse(example)
-      comment << "Error #{instance.webdriver.webdriver_screenshot}\n" if test_failed_and_has_no_screenshot?(result, example)
+      comment = "Error #{instance.webdriver.webdriver_screenshot}\n" if test_failed_and_has_no_screenshot?(result, example)
       formatting_describer(comment)
       @testrail&.add_result_to_test_case(example, comment)
 

--- a/lib/testing_site_onlyoffice/test_manger/test_manager.rb
+++ b/lib/testing_site_onlyoffice/test_manger/test_manager.rb
@@ -30,7 +30,7 @@ module TestingSiteOnlyoffice
     # @param [String] comment is a data for result
     def add_result(example, instance, comment = '')
       result = @tcm_helper.parse(example)
-      comment = "Error #{instance.webdriver.webdriver_screenshot}\n" if test_failed_and_has_no_screenshot?(result, example)
+      comment = "#{comment}Error #{instance.webdriver.webdriver_screenshot}\n" if test_failed_and_has_no_screenshot?(result, example)
       formatting_describer(comment)
       @testrail&.add_result_to_test_case(example, comment)
 


### PR DESCRIPTION
Error `can't modify frozen String` raised due to rubocop changes in PR #246, where `# frozen_string_literal: true`
 magic command was added 
Fix #262