### PR TITLE
Add tests for Premium support page

### DIFF
--- a/lib/testing_site_onlyoffice/data/site_data.rb
+++ b/lib/testing_site_onlyoffice/data/site_data.rb
@@ -38,6 +38,10 @@ module TestingSiteOnlyoffice
       %w[en-US en-GB ru-RU fr-FR de-DE es-ES pt-BR it-IT cs-CZ nl-NL ja-JP zh-CN]
     end
 
+    def self.european_languages
+      %w[en-GB fr-FR de-DE es-ES it-IT cs-CZ nl-NL]
+    end
+
     def self.courses_modules
       {
         documents: 'Documents',

--- a/lib/testing_site_onlyoffice/data/site_prices_data.rb
+++ b/lib/testing_site_onlyoffice/data/site_prices_data.rb
@@ -30,5 +30,29 @@ module TestingSiteOnlyoffice
 
       1500
     end
+
+    def self.plus_support_50
+      return 1250 if SiteData.european_languages.include? config.language
+
+      1480
+    end
+
+    def self.plus_support_100
+      return 2000 if SiteData.european_languages.include? config.language
+
+      2380
+    end
+
+    def self.premium_support_50
+      return 3250 if SiteData.european_languages.include? config.language
+
+      3850
+    end
+
+    def self.premium_support_100
+      return 5200 if SiteData.european_languages.include? config.language
+
+      6160
+    end
   end
 end

--- a/lib/testing_site_onlyoffice/data/site_prices_data.rb
+++ b/lib/testing_site_onlyoffice/data/site_prices_data.rb
@@ -54,5 +54,12 @@ module TestingSiteOnlyoffice
 
       6160
     end
+
+    def self.support_users
+      {
+        min: 50,
+        min_increased: 100
+      }
+    end
   end
 end

--- a/lib/testing_site_onlyoffice/footer/support/premium_support/site_premium_support.rb
+++ b/lib/testing_site_onlyoffice/footer/support/premium_support/site_premium_support.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative '../../../pricing/modules/site_pricing_helper'
+require_relative '../../../pricing/site_pricing_docs_enterprise'
+
+module TestingSiteOnlyoffice
+  # /support.aspx
+  # https://user-images.githubusercontent.com/40513035/126144130-9be03fe2-f125-450b-aeb6-36a3fabd2e07.png
+  class SitePremiumSupport
+    include PageObject
+    include SitePricingHelper
+
+    link(:buy_now_support, xpath: '//a[@class="button red standartBuyButton"]')
+    link(:choose_your_plan, xpath: '//a[contains(@class, "basicBuyButton")]')
+
+    # Plus
+    link(:plus_get_a_quote, xpath: "//a[@class='button gray standartBuyButton']")
+    div(:plus_user_number, xpath: "//div[@id='standart-users-value']")
+    div(:increase_plus_users, xpath: "//div[contains(@class, 'standartSelectors') and @data-direction='right']")
+    div(:decrease_plus_users, xpath: "//div[contains(@class, 'standartSelectors') and @data-direction='left']")
+
+    # Premium
+    link(:premium_get_a_quote, xpath: "//a[@class='button gray premiumBuyButton']")
+    div(:premium_user_number, xpath: "//div[@id='premium-users-value']")
+    div(:increase_premium_users, xpath: "//div[contains(@class, 'premiumSelectors') and @data-direction='right']")
+    div(:decrease_premium_users, xpath: "//div[contains(@class, 'premiumSelectors') and @data-direction='left']")
+
+    def initialize(instance)
+      super(instance.webdriver.driver)
+      @instance = instance
+      wait_to_load
+    end
+
+    def wait_to_load
+      @instance.webdriver.wait_until do
+        buy_now_support_element.present?
+      end
+    end
+
+    def increase_plus_users
+      increase_plus_users_element.click
+    end
+
+    def decrease_plus_users
+      decrease_plus_users_element.click
+    end
+
+    def increase_premium_users
+      increase_premium_users_element.click
+    end
+
+    def decrease_premium_users
+      decrease_premium_users_element.click
+    end
+
+    def choose_your_plan
+      choose_your_plan_element.click
+      SitePriceDocsEnterprise.new(@instance)
+    end
+
+    def current_support_plus_price_and_user_number
+      user_number = plus_user_number_element.text
+      price_xpath = "//div[@data-value='#{user_number}' and @class='pp_sum standartSum']/span"
+      price = @instance.webdriver.driver.find_element(:xpath, price_xpath).text
+      [price, user_number]
+    end
+
+    def current_support_premium_price_and_user_number
+      user_number = premium_user_number_element.text
+      price_xpath = "//div[@data-value='#{user_number}' and @class='pp_sum premiumSum']/span"
+      price = @instance.webdriver.driver.find_element(:xpath, price_xpath).text
+      [price, user_number]
+    end
+
+    def plus_quote_email
+      @instance.webdriver.get_attribute(plus_get_a_quote_element, 'href')
+    end
+
+    def premium_quote_email
+      @instance.webdriver.get_attribute(premium_get_a_quote_element, 'href')
+    end
+  end
+end

--- a/lib/testing_site_onlyoffice/footer/support/premium_support/site_premium_support.rb
+++ b/lib/testing_site_onlyoffice/footer/support/premium_support/site_premium_support.rb
@@ -62,14 +62,14 @@ module TestingSiteOnlyoffice
       user_number = plus_user_number_element.text
       price_xpath = "//div[@data-value='#{user_number}' and @class='pp_sum standartSum']/span"
       price = @instance.webdriver.driver.find_element(:xpath, price_xpath).text
-      [price, user_number]
+      { price: price.to_i, user_number: user_number.to_i }
     end
 
     def current_support_premium_price_and_user_number
       user_number = premium_user_number_element.text
       price_xpath = "//div[@data-value='#{user_number}' and @class='pp_sum premiumSum']/span"
       price = @instance.webdriver.driver.find_element(:xpath, price_xpath).text
-      [price, user_number]
+      { price: price.to_i, user_number: user_number.to_i }
     end
 
     def plus_quote_email

--- a/lib/testing_site_onlyoffice/modules/site_footer.rb
+++ b/lib/testing_site_onlyoffice/modules/site_footer.rb
@@ -13,6 +13,7 @@ module TestingSiteOnlyoffice
     link(:help_center_footer_link, xpath: '//a[contains(@href,"helpcenter.onlyoffice.com/index.aspx")]')
 
     # support
+    link(:premium_support, xpath: '//a[@href="/support.aspx"]')
     link(:order_demo, xpath: '//a[@href="/demo-order.aspx"]')
     link(:support_contact_form, xpath: '//a[@href="/support-contact-form.aspx"]')
 
@@ -35,6 +36,11 @@ module TestingSiteOnlyoffice
     def click_order_demo
       order_demo_element.click
       SiteOrderDemo.new(@instance)
+    end
+
+    def click_premium_support
+      premium_support_element.click
+      SitePremiumSupport.new(@instance)
     end
 
     def click_support_contact_form

--- a/lib/testing_site_onlyoffice/site_home_page.rb
+++ b/lib/testing_site_onlyoffice/site_home_page.rb
@@ -15,6 +15,7 @@ require_relative 'data/site_private_data'
 
 require_relative 'footer/site_document_builder/site_document_builder'
 require_relative 'footer/contact_us/site_callback'
+require_relative 'footer/support/premium_support/site_premium_support'
 require_relative 'footer/support/site_order_demo'
 require_relative 'footer/support/site_support_contact_form'
 require_relative 'footer/follow_us_on/site_subscribe'

--- a/spec/functional/support/site_premium_support_spec.rb
+++ b/spec/functional/support/site_premium_support_spec.rb
@@ -32,7 +32,7 @@ describe 'Buy Product Notification' do
   it '[Site][PremiumSupport] Prices on store.onlyoffice.com and onlyoffice.com are the same for 100 users for `Plus` plan' do
     @premium_support_page.increase_plus_users
     plus_price_data = @premium_support_page.current_support_plus_price_and_user_number
-    expect(plus_price_data[:user_number]).to eq(100)
+    expect(plus_price_data[:user_number]).to eq(TestingSiteOnlyoffice::SitePricesData.support_users[:min_increased])
     avangate = @premium_support_page.go_to_avangate_from_pricing_page(@premium_support_page.buy_now_support_element, test_purchase: true)
     avangate_price = avangate.get_avangate_current_price_value.to_i
     expect(avangate_price).to eq(plus_price_data[:price])
@@ -53,22 +53,22 @@ describe 'Buy Product Notification' do
   it '[Pricing][PremiumSupport] `+` and `-` buttons work for `Plus` plan' do
     @premium_support_page.increase_plus_users
     plus_price_data = @premium_support_page.current_support_plus_price_and_user_number
-    expect(plus_price_data[:user_number]).to eq(100)
+    expect(plus_price_data[:user_number]).to eq(TestingSiteOnlyoffice::SitePricesData.support_users[:min_increased])
     expect(plus_price_data[:price]).to eq(TestingSiteOnlyoffice::SitePricesData.plus_support_100)
     @premium_support_page.decrease_plus_users
     plus_price_data = @premium_support_page.current_support_plus_price_and_user_number
-    expect(plus_price_data[:user_number]).to eq(50)
+    expect(plus_price_data[:user_number]).to eq(TestingSiteOnlyoffice::SitePricesData.support_users[:min])
     expect(plus_price_data[:price]).to eq(TestingSiteOnlyoffice::SitePricesData.plus_support_50)
   end
 
   it '[Pricing][PremiumSupport] `+` and `-` buttons work for `Premium` plan' do
     @premium_support_page.increase_premium_users
     premium_price_data = @premium_support_page.current_support_premium_price_and_user_number
-    expect(premium_price_data[:user_number]).to eq(100)
+    expect(premium_price_data[:user_number]).to eq(TestingSiteOnlyoffice::SitePricesData.support_users[:min_increased])
     expect(premium_price_data[:price]).to eq(TestingSiteOnlyoffice::SitePricesData.premium_support_100)
     @premium_support_page.decrease_premium_users
     premium_price_data = @premium_support_page.current_support_premium_price_and_user_number
-    expect(premium_price_data[:user_number]).to eq(50)
+    expect(premium_price_data[:user_number]).to eq(TestingSiteOnlyoffice::SitePricesData.support_users[:min])
     expect(premium_price_data[:price]).to eq(TestingSiteOnlyoffice::SitePricesData.premium_support_50)
   end
 end

--- a/spec/functional/support/site_premium_support_spec.rb
+++ b/spec/functional/support/site_premium_support_spec.rb
@@ -31,11 +31,11 @@ describe 'Buy Product Notification' do
 
   it '[Site][PremiumSupport] Prices on store.onlyoffice.com and onlyoffice.com are the same for 100 users for `Plus` plan' do
     @premium_support_page.increase_plus_users
-    price, user_number = @premium_support_page.current_support_plus_price_and_user_number
-    expect(user_number.to_i).to eq(100)
+    plus_price_data = @premium_support_page.current_support_plus_price_and_user_number
+    expect(plus_price_data[:user_number]).to eq(100)
     avangate = @premium_support_page.go_to_avangate_from_pricing_page(@premium_support_page.buy_now_support_element, test_purchase: true)
     avangate_price = avangate.get_avangate_current_price_value.to_i
-    expect(avangate_price).to eq(price.to_i)
+    expect(avangate_price).to eq(plus_price_data[:price])
   end
 
   it '[Pricing][PremiumSupport] `Get a quote` button for more then 200 users contains link to email for for `Plus` plan' do
@@ -52,23 +52,23 @@ describe 'Buy Product Notification' do
 
   it '[Pricing][PremiumSupport] `+` and `-` buttons work for `Plus` plan' do
     @premium_support_page.increase_plus_users
-    price, user_number = @premium_support_page.current_support_plus_price_and_user_number
-    expect(user_number.to_i).to eq(100)
-    expect(price.to_i).to eq(TestingSiteOnlyoffice::SitePricesData.plus_support_100)
+    plus_price_data = @premium_support_page.current_support_plus_price_and_user_number
+    expect(plus_price_data[:user_number]).to eq(100)
+    expect(plus_price_data[:price]).to eq(TestingSiteOnlyoffice::SitePricesData.plus_support_100)
     @premium_support_page.decrease_plus_users
-    price, user_number = @premium_support_page.current_support_plus_price_and_user_number
-    expect(user_number.to_i).to eq(50)
-    expect(price.to_i).to eq(TestingSiteOnlyoffice::SitePricesData.plus_support_50)
+    plus_price_data = @premium_support_page.current_support_plus_price_and_user_number
+    expect(plus_price_data[:user_number]).to eq(50)
+    expect(plus_price_data[:price]).to eq(TestingSiteOnlyoffice::SitePricesData.plus_support_50)
   end
 
   it '[Pricing][PremiumSupport] `+` and `-` buttons work for `Premium` plan' do
     @premium_support_page.increase_premium_users
-    price, user_number = @premium_support_page.current_support_premium_price_and_user_number
-    expect(user_number.to_i).to eq(100)
-    expect(price.to_i).to eq(TestingSiteOnlyoffice::SitePricesData.premium_support_100)
+    premium_price_data = @premium_support_page.current_support_premium_price_and_user_number
+    expect(premium_price_data[:user_number]).to eq(100)
+    expect(premium_price_data[:price]).to eq(TestingSiteOnlyoffice::SitePricesData.premium_support_100)
     @premium_support_page.decrease_premium_users
-    price, user_number = @premium_support_page.current_support_premium_price_and_user_number
-    expect(user_number.to_i).to eq(50)
-    expect(price.to_i).to eq(TestingSiteOnlyoffice::SitePricesData.premium_support_50)
+    premium_price_data = @premium_support_page.current_support_premium_price_and_user_number
+    expect(premium_price_data[:user_number]).to eq(50)
+    expect(premium_price_data[:price]).to eq(TestingSiteOnlyoffice::SitePricesData.premium_support_50)
   end
 end

--- a/spec/functional/support/site_premium_support_spec.rb
+++ b/spec/functional/support/site_premium_support_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Buy Product Notification' do
+  test_manager = TestingSiteOnlyoffice::TestManager.new(suite_name: File.basename(__FILE__))
+
+  before do
+    site_home_page, @test = TestingSiteOnlyoffice::SiteHelper.new.open_page_teamlab_office(config)
+    @mail = IredMailHelper.new(username: 'avangate-buy-product@qamail.teamlab.info',
+                               password: @test.private_data['mail_avangate-buy-product_pass'])
+    @premium_support_page = site_home_page.click_premium_support
+    @mail.delete_all_messages
+  end
+
+  after do |example|
+    test_manager.add_result(example, @test)
+    @test.webdriver.quit
+  end
+
+  it '[Site][PremiumSupport] Buy Premium Support Plus and check notify /support.aspx' do
+    pending('https://bugzilla.onlyoffice.com/show_bug.cgi?id=43150') if config.server.include?('.com')
+    avangate = @premium_support_page.go_to_avangate_from_pricing_page(@premium_support_page.buy_now_support_element, test_purchase: true)
+    avangate.submit_avangate_order_for_notification(email: @mail.username)
+    expect(@mail.check_email_by_subject({ subject: TestingSiteOnlyoffice::SiteNotificationData::PAYMENT_RECEIVED }, 300, true)).to be_truthy
+  end
+
+  it '[Site][PremiumSupport] `Choose your plan` button works for Basic plan' do
+    expect(@premium_support_page.choose_your_plan).to be_a TestingSiteOnlyoffice::SitePriceDocsEnterprise
+  end
+
+  it '[Site][PremiumSupport] Prices on store.onlyoffice.com and onlyoffice.com are the same for 100 users for `Plus` plan' do
+    @premium_support_page.increase_plus_users
+    price, user_number = @premium_support_page.current_support_plus_price_and_user_number
+    expect(user_number.to_i).to eq(100)
+    avangate = @premium_support_page.go_to_avangate_from_pricing_page(@premium_support_page.buy_now_support_element, test_purchase: true)
+    avangate_price = avangate.get_avangate_current_price_value.to_i
+    expect(avangate_price).to eq(price.to_i)
+  end
+
+  it '[Pricing][PremiumSupport] `Get a quote` button for more then 200 users contains link to email for for `Plus` plan' do
+    3.times { @premium_support_page.increase_plus_users }
+    expect(@premium_support_page.plus_get_a_quote_element).to be_present
+    expect(@premium_support_page.plus_quote_email).to start_with('mailto:sales@onlyoffice.com')
+  end
+
+  it '[Pricing][PremiumSupport] `Get a quote` button for more then 200 users contains link to email for for `Premium` plan' do
+    3.times { @premium_support_page.increase_premium_users }
+    expect(@premium_support_page.premium_get_a_quote_element).to be_present
+    expect(@premium_support_page.premium_quote_email).to start_with('mailto:sales@onlyoffice.com')
+  end
+
+  it '[Pricing][PremiumSupport] `+` and `-` buttons work for `Plus` plan' do
+    @premium_support_page.increase_plus_users
+    price, user_number = @premium_support_page.current_support_plus_price_and_user_number
+    expect(user_number.to_i).to eq(100)
+    expect(price.to_i).to eq(TestingSiteOnlyoffice::SitePricesData.plus_support_100)
+    @premium_support_page.decrease_plus_users
+    price, user_number = @premium_support_page.current_support_plus_price_and_user_number
+    expect(user_number.to_i).to eq(50)
+    expect(price.to_i).to eq(TestingSiteOnlyoffice::SitePricesData.plus_support_50)
+  end
+
+  it '[Pricing][PremiumSupport] `+` and `-` buttons work for `Premium` plan' do
+    @premium_support_page.increase_premium_users
+    price, user_number = @premium_support_page.current_support_premium_price_and_user_number
+    expect(user_number.to_i).to eq(100)
+    expect(price.to_i).to eq(TestingSiteOnlyoffice::SitePricesData.premium_support_100)
+    @premium_support_page.decrease_premium_users
+    price, user_number = @premium_support_page.current_support_premium_price_and_user_number
+    expect(user_number.to_i).to eq(50)
+    expect(price.to_i).to eq(TestingSiteOnlyoffice::SitePricesData.premium_support_50)
+  end
+end


### PR DESCRIPTION
Add tests for [Premium Support prices page](https://www.onlyoffice.com/support.aspx) 
Fix #208 
<img width="631" alt="Screen Shot 2021-07-19 at 03 08 36" src="https://user-images.githubusercontent.com/40513035/126144130-9be03fe2-f125-450b-aeb6-36a3fabd2e07.png">