### PR TITLE
Add additional wait so tests will not fail

### DIFF
--- a/lib/testing_site_onlyoffice/get_onlyoffice/modules/site_download_helper.rb
+++ b/lib/testing_site_onlyoffice/get_onlyoffice/modules/site_download_helper.rb
@@ -59,8 +59,18 @@ module TestingSiteOnlyoffice
     end
 
     def check_opened_page_title
+      long_page_load_timeout
       @instance.webdriver.choose_tab(2)
       @instance.webdriver.get_title_of_current_tab
+    end
+
+    # some page like https://helpcenter.onlyoffice.com/ or
+    # https://appimage.github.io/ONLYOFFICE/
+    # loads for very long time sometimes so page load timeout is failing
+    def long_page_load_timeout
+      timeout = 60
+      OnlyofficeLoggerHelper.log("Sleeping for #{timeout}seconds until checking that page correctly loaded")
+      sleep(timeout)
     end
   end
 end


### PR DESCRIPTION
Some pages on second-party resources like
helpcenter or third-party like appimage hub
loading for very long time sometime
And a lot of tests failing because of it

I hope this minor timeout will fix all issues