### PR TITLE
Check buying of Docs Enterprise Edition without support

### DIFF
--- a/lib/testing_site_onlyoffice/pricing/site_pricing_docs_enterprise.rb
+++ b/lib/testing_site_onlyoffice/pricing/site_pricing_docs_enterprise.rb
@@ -13,6 +13,8 @@ module TestingSiteOnlyoffice
 
     link(:buy_now_single_server, xpath: '//a[@id= "ie-price-url-updated"]')
 
+    div(:professional_support_basic, xpath: '//div[@id="basic_support"]')
+
     def initialize(instance)
       super(instance.webdriver.driver)
       @instance = instance
@@ -22,6 +24,13 @@ module TestingSiteOnlyoffice
     def wait_to_load
       @instance.webdriver.wait_until do
         buy_now_single_server_element.present?
+      end
+    end
+
+    def choose_support_basic
+      professional_support_basic_element.click
+      @instance.webdriver.wait_until do
+        professional_support_basic_element.attribute('class').include?('selected_sp')
       end
     end
   end

--- a/spec/functional/pricing/site_buy_notification_spec.rb
+++ b/spec/functional/pricing/site_buy_notification_spec.rb
@@ -27,6 +27,7 @@ describe 'Buy Product Notification' do
 
   it '[Site][PricingDocsEnterprise] Buy Docs Enterprise Edition and check notify /docs-enterprise-prices.aspx' do
     pricing_page = @site_home_page.click_link_on_toolbar(:pricing_enterprise)
+    pricing_page.choose_support_basic
     avangate = pricing_page.go_to_avangate_from_pricing_page(pricing_page.buy_now_single_server_element, test_purchase: true)
     avangate.submit_avangate_order_for_notification(email: @mail.username)
     expect(@mail.check_email_by_subject({ subject: TestingSiteOnlyoffice::SiteNotificationData::PAYMENT_RECEIVED }, 300, true)).to be_truthy


### PR DESCRIPTION
In the 1.54.0 site version default Docs Enterprise Edition is Plus version with Support. The welcome letter for Docs Enterprise Edition+Support will be released later.
For now, I am checking the Basic version without Support.