### PR TITLE
Show all specs  in TestRail(add_all_suites = true)

### DIFF
--- a/lib/testing_site_onlyoffice/test_manger/test_manager_testrail.rb
+++ b/lib/testing_site_onlyoffice/test_manger/test_manager_testrail.rb
@@ -9,7 +9,7 @@ module TestingSiteOnlyoffice
       return unless Testrail2.new.available?
 
       @testrail = TestrailHelper.new(params[:product_name], params[:suite_name], params[:plan_name_testrail]) do |testrail_conf|
-        testrail_conf.add_all_suites = false
+        testrail_conf.add_all_suites = true
         testrail_conf.search_plan_by_substring = false
       end
     end


### PR DESCRIPTION
Show all specs in TestRail even if there just one spec run

testrail_conf.add_all_suites = false

<img width="1058" alt="Screen Shot 2021-09-29 at 19 35 23" src="https://user-images.githubusercontent.com/40513035/135311367-5c0c0f7c-536d-4d0c-9413-231de93767d5.png">

testrail_conf.add_all_suites = true

<img width="1053" alt="Screen Shot 2021-09-29 at 19 36 55" src="https://user-images.githubusercontent.com/40513035/135311620-dd7003ed-1d02-4c76-a2ba-f99df156b2e0.png">


