### PR TITLE
Use Email only with English letters for "Sign Up" form

### DIFF
--- a/spec/functional/get_onlyoffice/site_registration_signin_spec.rb
+++ b/spec/functional/get_onlyoffice/site_registration_signin_spec.rb
@@ -47,6 +47,11 @@ describe 'Registration new portal' do
       expect(sign_up_page).to be_all_errors_visible
     end
 
+    it 'Use Email only with English letters for "Sign Up" form' do
+      sign_up_page.fill_params(email: 'rémy.rousseau@veolia.com')
+      expect(sign_up_page.email_error_element).to be_present
+    end
+
     it 'Check open "Term and conditions" link for "Sign Up' do
       sign_up_page.terms_and_conditions
       expect(sign_up_page.check_opened_file_name).to eq(TestingSiteOnlyoffice::SiteNotificationData::TERMS_OF_USE_FILE_NAME)

--- a/spec/functional/get_onlyoffice/site_registration_signin_spec.rb
+++ b/spec/functional/get_onlyoffice/site_registration_signin_spec.rb
@@ -48,7 +48,7 @@ describe 'Registration new portal' do
     end
 
     it 'Use Email only with English letters for "Sign Up" form' do
-      sign_up_page.fill_params(email: 'rémy.rousseau@veolia.com')
+      sign_up_page.fill_params(email: 'rémy@qamail.teamlab.info')
       expect(sign_up_page.email_error_element).to be_present
     end
 


### PR DESCRIPTION
Check that email could contain only English letters, same as for Portals