### PR TITLE
Add pending for two test with opening Documents

### DIFF
--- a/spec/functional/get_onlyoffice/site_registration_signin_spec.rb
+++ b/spec/functional/get_onlyoffice/site_registration_signin_spec.rb
@@ -53,11 +53,13 @@ describe 'Registration new portal' do
     end
 
     it 'Check open "Term and conditions" link for "Sign Up' do
+      pending('WebDriver raise chrome error for some unknown reason')
       sign_up_page.terms_and_conditions
       expect(sign_up_page.check_opened_file_name).to eq(TestingSiteOnlyoffice::SiteNotificationData::TERMS_OF_USE_FILE_NAME)
     end
 
     it 'Check open "Privacy statement" link for "Sign Up' do
+      pending('WebDriver raise chrome error for some unknown reason')
       sign_up_page.privacy_statement
       expect(sign_up_page.check_opened_file_name).to eq(TestingSiteOnlyoffice::SiteNotificationData::PRIVACY_STATEMENT)
     end


### PR DESCRIPTION
For some reason this test raise error that looks like this:
```
There are some errors in the Web Console: ["https://teamlab.info/?Site_Testing=4testing 380:62 Uncaught TypeError: Cannot read properties of null (reading 'split')"]
```

Problem is that this error NEVER shown when I tried to manually
reproduce it
And I never remember experience like this - I'm almost sure that some
error is happened during this test, but seems maybe some code just hide
it or maybe chrome for some reason hide it
I spend several hours trying different methods to catch this error
manually and there is no success
So I think I just pending this test and as soon as they start to be OK
we'll remove that pending. Not sure then
And sometimes we should check those pendings, I think they can
magically fix itself as they were magically broken