### PR TITLE
Refactoring name mobale app galary for different region

### DIFF
--- a/lib/testing_site_onlyoffice/data/site_download_data.rb
+++ b/lib/testing_site_onlyoffice/data/site_download_data.rb
@@ -23,7 +23,7 @@ module TestingSiteOnlyoffice
 
     # Mobile
     MOBILE_GOOGLE = 'ONLYOFFICE Documents - Apps on Google Play'
-    MOBILE_APP_GALLERY = 'HUAWEI AppGallery'
+    MOBILE_APP_GALLERY = 'AppGallery'
     MOBILE_APP_STORE = 'ONLYOFFICE Documents on the App Store'
     MOBILE_IOS_CHANGELOG = 'Documents app for iOS changelog - ONLYOFFICE'
 

--- a/spec/site_hourly_check_spec.rb
+++ b/spec/site_hourly_check_spec.rb
@@ -114,7 +114,7 @@ describe 'SiteHourlyCheck' do
 
         it 'Download Mobile Editors] /download-desktop.aspx: "Explore it on AppGallery" link works' do
           mobile_editors_download_page.site_mobile_appgallery
-          expect(mobile_editors_download_page.check_opened_page_title).to eq(TestingSiteOnlyoffice::SiteDownloadData::MOBILE_APP_GALLERY)
+          expect(mobile_editors_download_page.check_opened_page_title).to be_include(TestingSiteOnlyoffice::SiteDownloadData::MOBILE_APP_GALLERY)
         end
       end
 


### PR DESCRIPTION
Returns from the us region: AppGallery, other region: HUAWEI AppGallery