### PR TITLE
Actualize `nodejs` version in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Check source files using `rubocop`
         run: rubocop
       - uses: actions/setup-node@v1
+        with:
+          node-version: '16'
       - name: Check markdown files using `markdownlint`
         run: |
           npm install -g markdownlint-cli


### PR DESCRIPTION
Without it `markdownlint-cli` started to fail