### PR TITLE
Since yesterday update of site there is two links in download page

### DIFF
--- a/lib/testing_site_onlyoffice/modules/site_toolbar.rb
+++ b/lib/testing_site_onlyoffice/modules/site_toolbar.rb
@@ -66,7 +66,7 @@ module TestingSiteOnlyoffice
     link(:site_get_onlyoffice_sign_in, xpath: '//a[@id="navitem_download_signin"]')
     link(:site_get_onlyoffice_sign_up, xpath: '//a[@id="navitem_download_signup"]')
     link(:site_get_onlyoffice_docs_registration, xpath: '//a[@id="navitem_download_signup_docs"]')
-    link(:site_get_onlyoffice_docs_download, xpath: '//a[@id="navitem_download_onpremises_docs"]')
+    link(:site_get_onlyoffice_docs_download, xpath: '//a[@id="navitem_download_onpremises_docs"] | //a[@id="navitem_download_onpremises_docs_ee"]')
     link(:site_get_onlyoffice_install_onpremises, xpath: '//a[@id="navitem_download_onpremises"]')
     link(:site_get_onlyoffice_desktop_mobile, xpath: '//a[@id="navitem_download_desktop"]')
     link(:site_get_onlyoffice_other_products, xpath: '//a[@id="navitem_download_products"]')


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/668524/181465925-5450d43c-1eb0-4b81-ae6a-915c8613c5d7.png)

After:
![image](https://user-images.githubusercontent.com/668524/181465883-6f1183a2-e576-494e-8b3b-e50a737c7593.png)
