### PR TITLE
Fix rubocop `CI` task

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -38,4 +38,4 @@ jobs:
           bundle config set with 'development'
           bundle install
       - name: Run Rubocop
-        run: rubocop
+        run: bundle exec rubocop


### PR DESCRIPTION
Run inside bundle env, so locked version of gems used And not the latest installed

Was broken in GitHub Actions self-hosted